### PR TITLE
Initial implementations of the Puzzle messages

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -347,12 +347,12 @@ fn emit_client_hello_for_retry(
     }
 
     if let Some(challenge) = retryreq.and_then(|r| r.puzzle_challenge()) {
-        let Some(solution) = challenge.solve() else {
-            return Err(cx.common.send_fatal_alert(
+        let solution = challenge.solve().ok_or_else(|| {
+            cx.common.send_fatal_alert(
                 AlertDescription::IllegalParameter,
                 PeerMisbehaved::IllegalHelloRetryRequestWithUnsolvablePuzzle,
-            ));
-        };
+            )
+        })?;
         exts.push(ClientExtension::ClientPuzzle(solution));
     } else {
         exts.push(ClientExtension::ClientPuzzle(

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -161,6 +161,8 @@ pub enum InvalidMessage {
     InvalidKeyUpdate,
     /// A peer's server name could not be decoded
     InvalidServerName,
+    /// A peer's puzzle extension could not be decoded
+    InvalidClientPuzzle,
     /// A TLS message payload was larger then allowed by the specification.
     MessageTooLarge,
     /// Message is shorter than the expected length
@@ -227,6 +229,7 @@ pub enum PeerMisbehaved {
     IllegalHelloRetryRequestWithUnsupportedVersion,
     IllegalHelloRetryRequestWithWrongSessionId,
     IllegalHelloRetryRequestWithInvalidEch,
+    IllegalHelloRetryRequestWithUnsolvablePuzzle,
     IllegalMiddleboxChangeCipherSpec,
     IllegalTlsInnerPlaintext,
     IncorrectBinder,
@@ -307,6 +310,7 @@ pub enum PeerIncompatible {
     NoEcPointFormatsInCommon,
     NoKxGroupsInCommon,
     NoSignatureSchemesInCommon,
+    NoPuzzleInCommon,
     NullCompressionRequired,
     ServerDoesNotSupportTls12Or13,
     ServerSentHelloRetryRequestWithUnknownExtension,

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -118,6 +118,7 @@ enum_builder! {
         TransportParametersDraft => 0xffa5,
         EncryptedClientHello => 0xfe0d, // https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-11.1
         EncryptedClientHelloOuterExtensions => 0xfd00, // https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-5.1
+        ClientPuzzleExtension => 0xff00,
     }
 }
 
@@ -387,6 +388,17 @@ enum_builder! {
     }
 }
 
+enum_builder! {
+    /// The type of a client puzzle
+    ///
+    /// Specified as part of the client puzzles draft
+    /// TODO(XXX): Update reference once draft is available.alloc
+    @U16
+    pub enum ClientPuzzleType {
+        COOKIE => 0,
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     // These tests are intended to provide coverage and
@@ -437,6 +449,7 @@ pub(crate) mod tests {
             CertificateStatusType::OCSP,
             CertificateStatusType::OCSP,
         );
+        test_enum16::<ClientPuzzleType>(ClientPuzzleType::COOKIE, ClientPuzzleType::COOKIE);
     }
 
     pub(crate) fn test_enum8<T: for<'a> Codec<'a>>(first: T, last: T) {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -538,15 +538,15 @@ pub enum ClientPuzzle {
 impl Codec<'_> for ClientPuzzle {
     fn encode(&self, bytes: &mut Vec<u8>) {
         match self {
-            ClientPuzzle::SupportIndication(supported) => {
+            Self::SupportIndication(supported) => {
                 supported.encode(bytes);
                 PayloadU16::empty().encode(bytes);
             }
-            ClientPuzzle::Cookie(cookie) => {
+            Self::Cookie(cookie) => {
                 vec![ClientPuzzleType::COOKIE].encode(bytes);
                 cookie.encode(bytes);
             }
-            ClientPuzzle::Unknown(puzzletype, data) => {
+            Self::Unknown(puzzletype, data) => {
                 vec![*puzzletype].encode(bytes);
                 data.encode(bytes);
             }
@@ -623,10 +623,10 @@ impl ClientPuzzleChallenge {
 
     pub fn solve(&self) -> Option<ClientPuzzle> {
         match self {
-            ClientPuzzleChallenge::Cookie(challenge) => {
+            Self::Cookie(challenge) => {
                 Some(ClientPuzzle::Cookie(challenge.clone()))
             }
-            ClientPuzzleChallenge::Unknown(_, _) => None,
+            Self::Unknown(_, _) => None,
         }
     }
 }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -23,13 +23,13 @@ use crate::log::warn;
 use crate::msgs::base::{Payload, PayloadU16, PayloadU24, PayloadU8};
 use crate::msgs::codec::{self, Codec, LengthPrefixedBuffer, ListLength, Reader, TlsListElement};
 use crate::msgs::enums::{
-    CertificateStatusType, ClientCertificateType, Compression, ECCurveType, ECPointFormat,
-    EchVersion, ExtensionType, HpkeAead, HpkeKdf, HpkeKem, KeyUpdateRequest, NamedGroup,
-    PSKKeyExchangeMode, ServerNameType,
+    CertificateStatusType, ClientCertificateType, ClientPuzzleType, Compression, ECCurveType,
+    ECPointFormat, EchVersion, ExtensionType, HpkeAead, HpkeKdf, HpkeKem, KeyUpdateRequest,
+    NamedGroup, PSKKeyExchangeMode, ServerNameType,
 };
-use crate::rand;
 use crate::verify::DigitallySignedStruct;
 use crate::x509::wrap_in_sequence;
+use crate::{rand, Error};
 
 /// Create a newtype wrapper around a given type.
 ///
@@ -522,6 +522,111 @@ impl CertificateStatusRequest {
     }
 }
 
+// TLS client puzzles draft
+
+impl TlsListElement for ClientPuzzleType {
+    const SIZE_LEN: ListLength = ListLength::U8;
+}
+
+#[derive(Clone, Debug)]
+pub struct ClientPuzzleExtension {
+    puzzle_type: Vec<ClientPuzzleType>,
+    client_puzzle_challenge_response: PayloadU16,
+}
+
+impl Codec<'_> for ClientPuzzleExtension {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.puzzle_type.encode(bytes);
+        self.client_puzzle_challenge_response
+            .encode(bytes);
+    }
+
+    fn read(r: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
+        Ok(Self {
+            puzzle_type: Vec::read(r)?,
+            client_puzzle_challenge_response: PayloadU16::read(r)?,
+        })
+    }
+}
+
+impl ClientPuzzleExtension {
+    pub fn from_challenge(challenge: ClientPuzzleChallenge) -> Self {
+        match challenge {
+            ClientPuzzleChallenge::Cookie(challenge) => Self {
+                puzzle_type: vec![ClientPuzzleType::COOKIE],
+                client_puzzle_challenge_response: PayloadU16::new(challenge),
+            },
+        }
+    }
+
+    pub fn from_solution(solution: ClientPuzzleSolution) -> Self {
+        match solution {
+            ClientPuzzleSolution::Cookie(solution) => Self {
+                puzzle_type: vec![ClientPuzzleType::COOKIE],
+                client_puzzle_challenge_response: PayloadU16::new(solution),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ClientPuzzleChallenge {
+    Cookie(Vec<u8>),
+}
+
+#[derive(Debug, Clone)]
+pub enum ClientPuzzleSolution {
+    Cookie(Vec<u8>),
+}
+
+impl ClientPuzzleChallenge {
+    pub fn new_cookie(secure_random: &dyn SecureRandom) -> Result<Self, Error> {
+        let mut challenge = vec![0; 16];
+        secure_random.fill(&mut challenge)?;
+        Ok(Self::Cookie(challenge))
+    }
+
+    pub fn from_extension(puzzle: &ClientPuzzleExtension) -> Option<Self> {
+        match &puzzle.puzzle_type[..] {
+            [ClientPuzzleType::COOKIE] => Some(Self::Cookie(
+                puzzle
+                    .client_puzzle_challenge_response
+                    .0
+                    .clone(),
+            )),
+            _ => None,
+        }
+    }
+
+    pub fn solve(self) -> ClientPuzzleSolution {
+        match self {
+            Self::Cookie(challenge) => ClientPuzzleSolution::Cookie(challenge),
+        }
+    }
+
+    pub fn check(&self, solution: &ClientPuzzleSolution) -> bool {
+        match (self, solution) {
+            (Self::Cookie(challenge), ClientPuzzleSolution::Cookie(response)) => {
+                challenge == response
+            }
+        }
+    }
+}
+
+impl ClientPuzzleSolution {
+    pub fn from_extension(puzzle: &ClientPuzzleExtension) -> Option<Self> {
+        match &puzzle.puzzle_type[..] {
+            [ClientPuzzleType::COOKIE] => Some(Self::Cookie(
+                puzzle
+                    .client_puzzle_challenge_response
+                    .0
+                    .clone(),
+            )),
+            _ => None,
+        }
+    }
+}
+
 // ---
 
 impl TlsListElement for PSKKeyExchangeMode {
@@ -561,6 +666,7 @@ pub enum ClientExtension {
     CertificateCompressionAlgorithms(Vec<CertificateCompressionAlgorithm>),
     EncryptedClientHello(EncryptedClientHello),
     EncryptedClientHelloOuterExtensions(Vec<ExtensionType>),
+    ClientPuzzle(ClientPuzzleExtension),
     Unknown(UnknownExtension),
 }
 
@@ -588,6 +694,7 @@ impl ClientExtension {
             Self::EncryptedClientHelloOuterExtensions(_) => {
                 ExtensionType::EncryptedClientHelloOuterExtensions
             }
+            Self::ClientPuzzle(_) => ExtensionType::ClientPuzzleExtension,
             Self::Unknown(ref r) => r.typ,
         }
     }
@@ -620,6 +727,7 @@ impl Codec<'_> for ClientExtension {
             Self::CertificateCompressionAlgorithms(ref r) => r.encode(nested.buf),
             Self::EncryptedClientHello(ref r) => r.encode(nested.buf),
             Self::EncryptedClientHelloOuterExtensions(ref r) => r.encode(nested.buf),
+            Self::ClientPuzzle(ref r) => r.encode(nested.buf),
             Self::Unknown(ref r) => r.encode(nested.buf),
         }
     }
@@ -665,6 +773,9 @@ impl Codec<'_> for ClientExtension {
             }
             ExtensionType::EncryptedClientHelloOuterExtensions => {
                 Self::EncryptedClientHelloOuterExtensions(Vec::read(&mut sub)?)
+            }
+            ExtensionType::ClientPuzzleExtension => {
+                Self::ClientPuzzle(ClientPuzzleExtension::read(&mut sub)?)
             }
             _ => Self::Unknown(UnknownExtension::read(typ, &mut sub)),
         };
@@ -1115,6 +1226,16 @@ impl ClientHelloPayload {
             false
         }
     }
+
+    pub fn puzzle_solution(&self) -> Option<ClientPuzzleSolution> {
+        let ext = self.find_extension(ExtensionType::ClientPuzzleExtension)?;
+        match ext {
+            ClientExtension::ClientPuzzle(solution) => {
+                ClientPuzzleSolution::from_extension(solution)
+            }
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1123,6 +1244,7 @@ pub(crate) enum HelloRetryExtension {
     Cookie(PayloadU16),
     SupportedVersions(ProtocolVersion),
     EchHelloRetryRequest(Vec<u8>),
+    ClientPuzzle(ClientPuzzleExtension),
     Unknown(UnknownExtension),
 }
 
@@ -1133,6 +1255,7 @@ impl HelloRetryExtension {
             Self::Cookie(_) => ExtensionType::Cookie,
             Self::SupportedVersions(_) => ExtensionType::SupportedVersions,
             Self::EchHelloRetryRequest(_) => ExtensionType::EncryptedClientHello,
+            Self::ClientPuzzle(_) => ExtensionType::ClientPuzzleExtension,
             Self::Unknown(ref r) => r.typ,
         }
     }
@@ -1150,6 +1273,7 @@ impl Codec<'_> for HelloRetryExtension {
             Self::EchHelloRetryRequest(ref r) => {
                 nested.buf.extend_from_slice(r);
             }
+            Self::ClientPuzzle(ref r) => r.encode(nested.buf),
             Self::Unknown(ref r) => r.encode(nested.buf),
         }
     }
@@ -1166,6 +1290,9 @@ impl Codec<'_> for HelloRetryExtension {
                 Self::SupportedVersions(ProtocolVersion::read(&mut sub)?)
             }
             ExtensionType::EncryptedClientHello => Self::EchHelloRetryRequest(sub.rest().to_vec()),
+            ExtensionType::ClientPuzzleExtension => {
+                Self::ClientPuzzle(ClientPuzzleExtension::read(&mut sub)?)
+            }
             _ => Self::Unknown(UnknownExtension::read(typ, &mut sub)),
         };
 
@@ -1226,6 +1353,7 @@ impl HelloRetryRequest {
                 && ext.ext_type() != ExtensionType::SupportedVersions
                 && ext.ext_type() != ExtensionType::Cookie
                 && ext.ext_type() != ExtensionType::EncryptedClientHello
+                && ext.ext_type() != ExtensionType::ClientPuzzleExtension
         })
     }
 
@@ -1263,6 +1391,16 @@ impl HelloRetryRequest {
         let ext = self.find_extension(ExtensionType::EncryptedClientHello)?;
         match *ext {
             HelloRetryExtension::EchHelloRetryRequest(ref ech) => Some(ech),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn puzzle_challenge(&self) -> Option<ClientPuzzleChallenge> {
+        let ext = self.find_extension(ExtensionType::ClientPuzzleExtension)?;
+        match *ext {
+            HelloRetryExtension::ClientPuzzle(ref challenge) => {
+                ClientPuzzleChallenge::from_extension(challenge)
+            }
             _ => None,
         }
     }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -23,8 +23,8 @@ use crate::msgs::enums::{Compression, ExtensionType, NamedGroup};
 #[cfg(feature = "tls12")]
 use crate::msgs::handshake::SessionId;
 use crate::msgs::handshake::{
-    ClientHelloPayload, ConvertProtocolNameList, ConvertServerNameList, HandshakePayload,
-    KeyExchangeAlgorithm, Random, ServerExtension,
+    ClientHelloPayload, ClientPuzzleChallenge, ConvertProtocolNameList, ConvertServerNameList,
+    HandshakePayload, KeyExchangeAlgorithm, Random, ServerExtension,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -213,6 +213,7 @@ pub(super) struct ExpectClientHello {
     #[cfg(feature = "tls12")]
     pub(super) using_ems: bool,
     pub(super) done_retry: bool,
+    pub(super) challenge: Option<ClientPuzzleChallenge>,
     pub(super) send_tickets: usize,
 }
 
@@ -233,6 +234,7 @@ impl ExpectClientHello {
             #[cfg(feature = "tls12")]
             using_ems: false,
             done_retry: false,
+            challenge: None,
             send_tickets: 0,
         }
     }
@@ -383,6 +385,7 @@ impl ExpectClientHello {
                 suite,
                 randoms,
                 done_retry: self.done_retry,
+                challenge: self.challenge,
                 send_tickets: self.send_tickets,
                 extra_exts: self.extra_exts,
             }


### PR DESCRIPTION
Some tests still fail, most likely because they assume exact structures of messages sent, which the puzzle adds bytes to.